### PR TITLE
⚡️ remove phpseclib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "guzzlehttp/guzzle": "^6.0|^7.4",
-        "phpseclib/phpseclib": "^3.0",
+        "guzzlehttp/guzzle": "^6.0|^7.4",        
         "ext-json": "*",
         "ext-openssl": "*"
     },

--- a/tests/PesaTest.php
+++ b/tests/PesaTest.php
@@ -88,7 +88,6 @@ class PesaTest extends TestCase
     {
         $this->assertClassHasAttribute('options', get_class($this->pesa));
         $this->assertClassHasAttribute('client', get_class($this->pesa));
-        $this->assertClassHasAttribute('rsa', get_class($this->pesa));
     }
 
 


### PR DESCRIPTION
Since the package only uses one feature of phpseclib, its best to remove
it as a dependency, and use PHP core functions